### PR TITLE
Restore dot indicators on encouragement popups

### DIFF
--- a/WalkWorthy/WalkWorthy/UI/Popups/EncouragementPopupsView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Popups/EncouragementPopupsView.swift
@@ -42,6 +42,17 @@ struct EncouragementPopupsView: View {
                     UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                 }
 
+                HStack(spacing: 8) {
+                    ForEach(Array(cards.indices), id: \.self) { idx in
+                        Circle()
+                            .fill(idx == index ? Color.primary : Color.secondary.opacity(0.3))
+                            .frame(width: idx == index ? 10 : 8, height: idx == index ? 10 : 8)
+                            .animation(.easeInOut(duration: 0.2), value: index)
+                    }
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Page \(index + 1) of \(cards.count)")
+
                 Button(action: onDismiss) {
                     Label("Done", systemImage: "checkmark.circle.fill")
                         .font(.headline)


### PR DESCRIPTION
## Summary
- add a custom dot indicator below the encouragement carousel to replace the missing page control
- highlight the current page with a larger, primary-colored dot while keeping inactive dots subtle
- provide accessibility text announcing the current page out of the total count

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e341a642188328832d7f9408b19ed7