### PR TITLE
Revert "Merge pull request #7 from Njones27/codex/add-dots-to-pop-ups"

### DIFF
--- a/WalkWorthy/WalkWorthy/UI/Popups/EncouragementPopupsView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Popups/EncouragementPopupsView.swift
@@ -42,17 +42,6 @@ struct EncouragementPopupsView: View {
                     UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                 }
 
-                HStack(spacing: 8) {
-                    ForEach(Array(cards.indices), id: \.self) { idx in
-                        Circle()
-                            .fill(idx == index ? Color.primary : Color.secondary.opacity(0.3))
-                            .frame(width: idx == index ? 10 : 8, height: idx == index ? 10 : 8)
-                            .animation(.easeInOut(duration: 0.2), value: index)
-                    }
-                }
-                .accessibilityElement(children: .ignore)
-                .accessibilityLabel("Page \(index + 1) of \(cards.count)")
-
                 Button(action: onDismiss) {
                     Label("Done", systemImage: "checkmark.circle.fill")
                         .font(.headline)


### PR DESCRIPTION
## Summary
- revert the merge that added a custom page indicator to the encouragement popups so the default single indicator is restored

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3556e48e483288366d5e9e76a6c9f