### PR TITLE
Fix deprecated onChange usage in onboarding form

### DIFF
--- a/WalkWorthy/WalkWorthy/UI/Onboarding/OnboardingForm.swift
+++ b/WalkWorthy/WalkWorthy/UI/Onboarding/OnboardingForm.swift
@@ -56,13 +56,13 @@ struct OnboardingForm: View {
         }
         .background(gradient)
         .onAppear(perform: loadProfile)
-        .onChange(of: ageText) { _ in
+        .onChange(of: ageText) {
             if ageError != nil { ageError = nil }
         }
-        .onChange(of: major) { _ in
+        .onChange(of: major) {
             if majorError != nil { majorError = nil }
         }
-        .onChange(of: selectedHobbies) { _ in
+        .onChange(of: selectedHobbies) {
             if hobbiesError != nil { hobbiesError = nil }
         }
         .navigationTitle("Let's personalize")


### PR DESCRIPTION
## Summary
- replace deprecated `onChange` handlers in the onboarding form with the modern zero-parameter closure variant
- ensure profile validation errors reset without relying on deprecated APIs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3d0325c108328bc84ac0e17b3b062