### PR TITLE
Adjust encouragement popup layout

### DIFF
--- a/WalkWorthy/WalkWorthy/UI/Popups/EncouragementPopupsView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Popups/EncouragementPopupsView.swift
@@ -45,18 +45,28 @@ struct EncouragementPopupsView: View {
                     impactGenerator.prepare()
                 }
 
+                Spacer(minLength: 0)
+
                 Button(action: onDismiss) {
                     Label("Done", systemImage: "checkmark.circle.fill")
                         .font(.headline)
                         .frame(maxWidth: .infinity)
                         .padding()
-                        .background(LinearGradient(colors: [Color.accentColor.opacity(0.85), Color.accentColor], startPoint: .topLeading, endPoint: .bottomTrailing), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                        .background(
+                            LinearGradient(
+                                colors: [Color.accentColor.opacity(0.85), Color.accentColor],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            ),
+                            in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        )
                         .foregroundStyle(Color.white)
                 }
                 .buttonStyle(.plain)
                 .padding(.horizontal, 24)
             }
             .padding(.vertical, 40)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .background(Color(.systemBackground).opacity(0.95))
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {


### PR DESCRIPTION
## Summary
- insert flexible spacer between the encouragement carousel and the done button so the action sits lower on the sheet
- keep existing styling while balancing vertical composition of the popup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e45f64b0308328adacb7cf7db48000