### PR TITLE
Anchor encouragement popup action to bottom quarter

### DIFF
--- a/WalkWorthy/WalkWorthy/UI/Popups/EncouragementPopupsView.swift
+++ b/WalkWorthy/WalkWorthy/UI/Popups/EncouragementPopupsView.swift
@@ -17,56 +17,75 @@ struct EncouragementPopupsView: View {
     private let impactGenerator = UIImpactFeedbackGenerator(style: .medium)
 
     var body: some View {
-        NavigationStack {
-            VStack(spacing: 24) {
-                TabView(selection: $index) {
-                    ForEach(Array(cards.enumerated()), id: \.element.id) { idx, card in
-                        VStack(alignment: .leading, spacing: 16) {
-                            Text(card.tag.uppercased())
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(.secondary)
-                                .tracking(1.2)
-                            Text(card.title)
-                                .font(.title2.weight(.bold))
-                            Text(card.message)
-                                .font(.body)
-                                .foregroundStyle(.primary)
-                                .fixedSize(horizontal: false, vertical: true)
+        GeometryReader { proxy in
+            NavigationStack {
+                VStack(spacing: 24) {
+                    TabView(selection: $index) {
+                        ForEach(Array(cards.enumerated()), id: \.element.id) { idx, card in
+                            VStack(alignment: .leading, spacing: 16) {
+                                Text(card.tag.uppercased())
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+                                    .tracking(1.2)
+                                Text(card.title)
+                                    .font(.title2.weight(.bold))
+                                Text(card.message)
+                                    .font(.body)
+                                    .foregroundStyle(.primary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            .glassCard()
+                            .padding(.horizontal, 24)
+                            .tag(idx)
                         }
-                        .glassCard()
-                        .padding(.horizontal, 24)
-                        .tag(idx)
                     }
-                }
-                .tabViewStyle(.page(indexDisplayMode: .always))
-                .frame(height: 340)
-                .onChange(of: index) { _, _ in
-                    impactGenerator.impactOccurred()
-                    impactGenerator.prepare()
-                }
+                    .tabViewStyle(.page(indexDisplayMode: .always))
+                    .frame(height: 340)
+                    .onChange(of: index) { _, _ in
+                        impactGenerator.impactOccurred()
+                        impactGenerator.prepare()
+                    }
 
-                Button(action: onDismiss) {
-                    Label("Done", systemImage: "checkmark.circle.fill")
-                        .font(.headline)
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(LinearGradient(colors: [Color.accentColor.opacity(0.85), Color.accentColor], startPoint: .topLeading, endPoint: .bottomTrailing), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-                        .foregroundStyle(Color.white)
+                    Spacer(minLength: 0)
+
+                    VStack(spacing: 0) {
+                        Spacer(minLength: 0)
+
+                        Button(action: onDismiss) {
+                            Label("Done", systemImage: "checkmark.circle.fill")
+                                .font(.headline)
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(
+                                    LinearGradient(
+                                        colors: [Color.accentColor.opacity(0.85), Color.accentColor],
+                                        startPoint: .topLeading,
+                                        endPoint: .bottomTrailing
+                                    ),
+                                    in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                )
+                                .foregroundStyle(Color.white)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .frame(height: proxy.size.height * 0.25, alignment: .bottom)
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, proxy.safeAreaInsets.bottom + 24)
                 }
-                .buttonStyle(.plain)
-                .padding(.horizontal, 24)
-            }
-            .padding(.vertical, 40)
-            .background(Color(.systemBackground).opacity(0.95))
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button(action: onDismiss) {
-                        Image(systemName: "xmark")
+                .padding(.top, 40)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                .background(Color(.systemBackground).opacity(0.95))
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button(action: onDismiss) {
+                            Image(systemName: "xmark")
+                        }
                     }
                 }
+                .navigationTitle("Burst of encouragement")
+                .toolbarTitleDisplayMode(.inline)
             }
-            .navigationTitle("Burst of encouragement")
-            .toolbarTitleDisplayMode(.inline)
         }
         .onAppear {
             impactGenerator.prepare()


### PR DESCRIPTION
## Summary
- wrap the encouragement popup in a geometry reader to access viewport sizing
- allocate the bottom quarter of the sheet to the Done button so it rests naturally near the bottom edge

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e45f64b0308328adacb7cf7db48000